### PR TITLE
Updates nwws.py to use Slixmpp instead of outdated Sleekxmpp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,14 @@
-FROM ubuntu:22.04
+FROM python:3
 
 # Set working directory
 WORKDIR /app
 
 # Copy required files to work directory
 COPY nwws.py .
-
-# Don't prompt for questions during apt-get
-ENV DEBIAN_FRONTEND noninteractive
-
-# Clean out apt cache
-RUN apt-get clean && rm -rf /var/lib/apt/lists/*
-
-# Update package repository
-RUN apt-get update
+COPY requirements.txt .
 
 # Run apt update
-RUN apt-get install -y python3-pip python3-pyasn1 python3-pyasn1-modules python3-sleekxmpp
-
-# Fix SleekXMPP & Python 3.10 collections issue 
-RUN sed -i.orig 's/^import collections/import collections.abc/' /usr/lib/python3/dist-packages/sleekxmpp/thirdparty/orderedset.py
-RUN sed -i.orig 's/^class OrderedSet(collections.MutableSet):/class OrderedSet(collections.abc.MutableSet):/' /usr/lib/python3/dist-packages/sleekxmpp/thirdparty/orderedset.py
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Run NWWS ingester
-CMD ["python3","nwws.py","config.json"]
+CMD ["python", "nwws.py", "config.json"]

--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 
 # nwws-python-client
 
-This is a simple product download client for the NWWS-OI ([NOAA Weather Wire Service](http://www.nws.noaa.gov/nwws/) Open Interface) written in Python. The NOAA Weather Wire Service is a satellite data collection and dissemination system operated by the [National Weather Service](http://weather.gov), which was established in October 2000. Its purpose is to provide state and federal government, commercial users, media and private citizens with timely delivery of meteorological, hydrological, climatological and geophysical information. 
+This is a simple product download client for the NWWS-OI ([NOAA Weather Wire Service](http://www.nws.noaa.gov/nwws/) Open Interface) written in Python. The NOAA Weather Wire Service is a satellite 
+data collection and dissemination system operated by the [National Weather Service](http://weather.gov), which was established in October 2000. Its purpose is to provide state and federal government, 
+commercial users, media and private citizens with timely delivery of meteorological, hydrological, climatological and geophysical information. 
 
-This client was developed and tested on [Ubuntu 22.04](http://ubuntu.com) using Python v3.10 and makes use of the [sleekxmpp](https://github.com/fritzy/SleekXMPP) Python library for connecting to the NWWS-2 OI XMPP-based server.
+This client was developed and tested on [Ubuntu 22.04](http://ubuntu.com) using Python v3.10 and makes use of the [slixmpp](https://slixmpp.readthedocs.io/en/latest/) Python library for connecting to 
+the NWWS OI XMPP-based server.
 
 ## How do I run it?
 
-It's now super simple to run this using [Docker](https://www.docker.com/) and [docker-compose](https://docs.docker.com/compose/). However, you'll need to first create a config file, documented below. 
+It's now super simple to run this using [Docker](https://www.docker.com/) and [docker-compose](https://docs.docker.com/compose/)! However, you'll need to first create a config file, documented below. 
 
 Once you have your config.json file created, create the directory that you'll save products to (e.g. `products`):
 
@@ -18,20 +21,19 @@ mkdir products
 Now, start up the client by running:
 
 ```
-docker-compose up
+docker compose up
 ```
 
 It will take care of building the Docker image and running it. You can also run the client in the background by running:
 
 ```
-docker-compose up -d
+docker compose up -d
 ```
 
-If you can't or don't want to use Docker, you can run it on Ubuntu or a Raspberry Pi (with Raspbian) by first installing the 
-SleekXMPP Python library by running:
+If you can't or don't want to use Docker, you can run it on Debian-based systems (Ubuntu, Raspberry Pi, Linux Mint) by first installing the Slixmpp Python library by running:
 
 ```
-sudo apt-get install python3-sleekxmpp -y
+sudo apt-get install python3-slixmpp -y
 ```
 
 You can then proceed to the section below 'Running the client outside of Docker' to run the client.
@@ -58,12 +60,14 @@ The NWWS Client requires a JSON config file using the following format:
 
 The variables `username` and `password` are required and refer to your NWWS-OI credentials obtained by signing up [on the NOAA Weather Wire Service website](http://www.nws.noaa.gov/nwws/#NWWS_OI_Request).
 
-You may use whatever string you would like for `resource`. The variable is required. Also, the NWWS-OI server keeps track of resource names, so you
-should make the name unique if you are running this client in multiple locations.
+You may use whatever string you would like for `resource`. The variable is required. Also, the NWWS-OI server keeps track of resource names, so you should make the name unique if you are running this 
+client in multiple locations.
 
-The `archivedir` variable is optional and specifies the directory on your system where you would like to store the downloaded products. The variable is optional in case you'd like to avoid saving products to your local system and only process them using a `pan_run` command, defined below.
+The `archivedir` variable is optional and specifies the directory on your system where you would like to store the downloaded products. The variable is optional in case you'd like to avoid saving products 
+to your local system and only process them using a `pan_run` command, defined below.
 
-The `pan_run` variable is also optional and specifies the path to a script or program that you'd like to run on product arrival. The client automatically passes the full path to the product to the supplied script or program. If `archivedir` is not specified, the product is temporarily saved to your `/tmp/` directory and then removed after the program or script is run.
+The `pan_run` variable is also optional and specifies the path to a script or program that you'd like to run on product arrival. The client automatically passes the full path to the product to the supplied 
+script or program. If `archivedir` is not specified, the product is temporarily saved to your `/tmp/` directory and then removed after the program or script is run.
 
 The `pan_run_log` variable is an optional variable to specify the log file where messages are run when the `pan_run` program script is run. Otherwise, the messages will be send to /dev/null.
 
@@ -74,19 +78,11 @@ The options `use_tls` and `use_ssl` are for specifying the security settings on 
 ## Running the client outside of Docker
 
 ```
-$ python3 nwws.py /path/to/config/file
+$ python nwws.py config.json
 ```
 
-#### Special note for those running Python 3.10 ####
-
-Python 3.10 has moved the collections module to collection.abc and the SleekXMPP has not yet updated their code yet to reflect this change. If you are running Python 3.10 (3.9 and below are not affected) you must run the following commands locally in order for the `nwws.py` to work.
-
-```
-sed -i.orig 's/^import collections/import collections.abc/' /usr/lib/python3/dist-packages/sleekxmpp/thirdparty/orderedset.py
-sed -i.orig 's/^class OrderedSet(collections.MutableSet):/class OrderedSet(collections.abc.MutableSet):/' /usr/lib/python3/dist-packages/sleekxmpp/thirdparty/orderedset.py
-```
-
-Provided that you're able to connect to the NWWS and your credentials are accepted, you will start to see products downloaded, and if the `archivedir` config variable was specified, you'll see the products saved to the directory in the following format:
+Provided that you're able to connect to the NWWS and your credentials are accepted, you will start to see products downloaded, and if the `archivedir` config variable was specified, you'll see the products 
+saved to the directory in the following format:
 
 ```
 [archivedir]/
@@ -102,7 +98,8 @@ The above variables have the following meaning:
 * `ddHHMM` - Day, hour, and minute of product issuance
 * `id` - Unique product ID
 
-The script will continue to run, downloading products to your system. If products are being archved, they will eventually fill up your filesystem and you'll likely want to clear out old products. For example, to automatically remove products older than a week, insert the following line into your crontab:
+The script will continue to run, downloading products to your system. If products are being archved, they will eventually fill up your filesystem and you'll likely want to clear out old products. For example, 
+to automatically remove products older than a week, insert the following line into your crontab:
 
 ```
 0 0 * * *   /usr/bin/find [archivedir] -type f -mtime +7 -delete >/dev/null
@@ -116,20 +113,20 @@ If you would like to run the client in the background, you can use GNU screen, t
 
 ```
 $ sudo apt-get install screen -y
-$ screen -d -m python3 nwws.py config.json
+$ screen -d -m python nwws.py config.json
 # Run the following to re-attach to the screen session. Type Ctrl+a d to detach
 $ screen -r
 ```
 
 ```
 $ sudo apt-get install tmux -y
-$ tmux new-session -d -s "nwws" python3 nwws.py config.json
+$ tmux new-session -d -s "nwws" python nwws.py config.json
 # Run the following to re-attach to the tmux session. Type Ctrl+b d to detach
 $ tmux a -t nwws
 ```
 
 ```
-$ nohup python3 -u nwws.py config.json >>nwws.log 2>&1 &
+$ nohup python -u nwws.py config.json >>nwws.log 2>&1 &
 # To tail the log file..
 $ tail -f nwws.log
 ```

--- a/compose.yml
+++ b/compose.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
     app:
         build:

--- a/nwws.py
+++ b/nwws.py
@@ -7,38 +7,30 @@ import logging
 import json
 import time
 import ssl
-import sleekxmpp
-from datetime import datetime
+import slixmpp
+from datetime import datetime, timezone
 from xml.dom import minidom
 
-# Python versions before 3.0 do not use UTF-8 encoding
-# by default. To ensure that Unicode is handled properly
-# throughout SleekXMPP, we will set the default encoding
-# ourselves to UTF-8.
-if sys.version_info < (3, 0):
-    reload(sys)
-    sys.setdefaultencoding('utf8')
-else:
-    raw_input = input
-
-def signal_handler(signal, frame):
+def sigint_handler(signal, frame):
     print('Caught Ctrl+C. Exiting.')
-    file = open('/tmp/exit_nwws', 'w')
-    file.close()
     sys.exit(0)
 
-signal.signal(signal.SIGINT, signal_handler)
+def sigpipe_handler(signal, frame):
+    print('Caught PIPE signal, exiting.', file=sys.stderr)
+    logging.info('Caught PIPE signal, exiting.')
+    sys.exit(0)
 
-class MUCBot(sleekxmpp.ClientXMPP):
+signal.signal(signal.SIGINT, sigint_handler)
+signal.signal(signal.SIGPIPE, sigpipe_handler)
+
+class MUCBot(slixmpp.ClientXMPP):
 
     """
-    A simple SleekXMPP bot that will greets those
-    who enter the room, and acknowledge any messages
-    that mentions the bot's nickname.
+    A simple Slixmpp bot.
     """
 
     def __init__(self, jid, password, room, nick):
-        sleekxmpp.ClientXMPP.__init__(self, jid, password)
+        slixmpp.ClientXMPP.__init__(self, jid, password)
 
         self.room = room
         self.nick = nick
@@ -51,20 +43,12 @@ class MUCBot(sleekxmpp.ClientXMPP):
         self.add_event_handler("session_start", self.start)
 
         # The groupchat_message event is triggered whenever a message
-        # stanza is received from any chat room. If you also also
+        # stanza is received from any chat room. If you also
         # register a handler for the 'message' event, MUC messages
         # will be processed by both handlers.
         self.add_event_handler("groupchat_message", self.muc_message)
 
-        # The groupchat_presence event is triggered whenever a
-        # presence stanza is received from any chat room, including
-        # any presences you send yourself. To limit event handling
-        # to a single room, use the events muc::room@server::presence,
-        # muc::room@server::got_online, or muc::room@server::got_offline.
-        self.add_event_handler("muc::%s::got_online" % self.room,
-                               self.muc_online)
-
-    def start(self, event):
+    async def start(self, event):
         """
         Process the session_start event.
 
@@ -77,13 +61,13 @@ class MUCBot(sleekxmpp.ClientXMPP):
                      event does not provide any additional
                      data.
         """
-        self.get_roster()
+        await self.get_roster()
         self.send_presence()
-        self.plugin['xep_0045'].joinMUC(self.room,
+        self.plugin['xep_0045'].join_muc(self.room,
                                         self.nick,
                                         # If a room password is needed, use:
                                         # password=the_room_password,
-                                        wait=True)
+        )
 
     def muc_message(self, msg):
         """
@@ -92,86 +76,53 @@ class MUCBot(sleekxmpp.ClientXMPP):
         message stanzas may be processed by both handlers, so check
         the 'type' attribute when using a 'message' event handler.
 
-        Whenever the bot's nickname is mentioned, respond to
-        the message.
-
-        IMPORTANT: Always check that a message is not from yourself,
-                   otherwise you will create an infinite loop responding
-                   to your own messages.
-
-        This handler will reply to messages that mention
-        the bot's nickname.
-
         Arguments:
             msg -- The received message stanza. See the documentation
                    for stanza objects and the Message stanza to see
                    how it may be used.
         """
-        #if msg['mucnick'] != self.nick and self.nick in msg['body']:
-        #    self.send_message(mto=msg['from'].bare,
-        #                      mbody="I heard that, %s." % msg['mucnick'],
-        #                      mtype='groupchat')
-        #print(str(msg))
-        print('INFO\t message stanza rcvd from nwws-oi saying... ' + msg['body'])
-        xmldoc = minidom.parseString(str(msg))
-        itemlist = xmldoc.getElementsByTagName('x')
-        ttaaii = itemlist[0].attributes['ttaaii'].value.lower()
-        cccc = itemlist[0].attributes['cccc'].value.lower()
-        awipsid = itemlist[0].attributes['awipsid'].value.lower()
-        id = itemlist[0].attributes['id'].value
-        content = itemlist[0].firstChild.nodeValue
-        if awipsid:
-            dayhourmin = datetime.utcnow().strftime("%d%H%M")
-            filename = cccc + '_' + ttaaii + '-' + awipsid + '.' + dayhourmin + '_' + id + '.txt'
-            print("DEBUG\t Writing " + filename, file=sys.stderr)
-            if not os.path.exists(config['archivedir'] + '/' + cccc):
-                os.makedirs(config['archivedir'] + '/' + cccc)
-            # Remove every other line
-            lines = content.splitlines()
-            pathtofile = config['archivedir'] + '/' + cccc + '/' + filename
-            f = open(pathtofile, 'w')
-            count = 0
-            for line in lines:
-                if count == 0 and line == '':
-                    continue
-                if count % 2 == 0:
-                    f.write(line + "\n")
-                count += 1
-            f.close()
-            # Run a command using the file as the parameter (if pan_run is defined in the config file)
-            if 'pan_run' in config:
-                try:
-                    os.system(config['pan_run']+' '+pathtofile+' >/dev/null')
-                except OSError as e:
-                    print("ERROR\t Execution failed: " + e, file=sys.stderr)
-
-    def muc_online(self, presence):
-        """
-        Process a presence stanza from a chat room. In this case,
-        presences from users that have just come online are
-        handled by sending a welcome message that includes
-        the user's nickname and role in the room.
-
-        Arguments:
-            presence -- The received presence stanza. See the
-                        documentation for the Presence stanza
-                        to see how else it may be used.
-        """
-        if presence['muc']['nick'] != self.nick:
-            self.send_message(mto=presence['from'].bare,
-                mbody="Hello, %s %s" % (presence['muc']['role'],
-                    presence['muc']['nick']),
-                mtype='groupchat')
-
+        try:
+            print('INFO\t message stanza rcvd from nwws-oi saying... ' + msg['body'])
+            xmldoc = minidom.parseString(str(msg))
+            itemlist = xmldoc.getElementsByTagName('x')
+            ttaaii = itemlist[0].attributes['ttaaii'].value.lower()
+            cccc = itemlist[0].attributes['cccc'].value.lower()
+            awipsid = itemlist[0].attributes['awipsid'].value.lower()
+            id = itemlist[0].attributes['id'].value
+            content = itemlist[0].firstChild.nodeValue
+            if awipsid:
+                dayhourmin = datetime.now(timezone.utc).strftime("%d%H%M")
+                filename = cccc + '_' + ttaaii + '-' + awipsid + '.' + dayhourmin + '_' + id + '.txt'
+                print("DEBUG\t Writing " + filename, file=sys.stderr)
+                if not os.path.exists(config['archivedir'] + '/' + cccc):
+                    os.makedirs(config['archivedir'] + '/' + cccc)
+                # Remove every other line
+                lines = content.splitlines()
+                pathtofile = config['archivedir'] + '/' + cccc + '/' + filename
+                f = open(pathtofile, 'w')
+                count = 0
+                for line in lines:
+                    if count == 0 and line == '':
+                        continue
+                    if count % 2 == 0:
+                        f.write(line + "\n")
+                    count += 1
+                f.close()
+                # Run a command using the file as the parameter (if pan_run is defined in the config file)
+                if 'pan_run' in config:
+                    try:
+                        os.system(config['pan_run']+' '+pathtofile+' >/dev/null')
+                    except OSError as e:
+                        print("ERROR\t Execution failed: " + e, file=sys.stderr)
+        except Exception as e:
+            print("ERROR\t Caught " + str(type(e)) + " exception:")
+            print(e)
 
 if __name__ == '__main__':
     # Check for command line arguments
     if len(sys.argv) == 1:
         print('Usage: '+sys.argv[0]+' /path/to/config')
         sys.exit(1)
-
-    # Setup logging.
-    logging.basicConfig(level=logging.INFO, format='%(levelname)-8s %(message)s')
 
     # Parse JSON config
     config = json.load(open('config.json'))
@@ -182,35 +133,34 @@ if __name__ == '__main__':
 
     # Start endless loop
     while True:
-
         # Setup the MUCBot and register plugins. Note that while plugins may
         # have interdependencies, the order in which you register them does
         # not matter.
-        xmpp = MUCBot(config['username'] + '@' + config['server'], config['password'], 'nwws@conference.' + config['server'], config['resource'])
+        xmpp = MUCBot(
+            config['username'] + '@' + config['server'],                # JID
+            config['password'],                                         # Password
+            'nwws@conference.' + config['server'],                      # Chat Room
+            config['resource']                                          # Resource/Nickname
+        )
         xmpp.register_plugin('xep_0030') # Service Discovery
         xmpp.register_plugin('xep_0045') # Multi-User Chat
         xmpp.register_plugin('xep_0199') # XMPP Ping
 
-        # nwws-oi.weather.gov now requires TLSv2.3
-        xmpp.ssl_version = ssl.PROTOCOL_SSLv23
+        # Connect to the XMPP server and start processing XMPP stanzas. If ConnectionResetError is encountered,
+        # catch the exception and reconnect to server
+        try:
+            print("INFO\t Connecting to XMPP server..")
+            xmpp.connect()
 
-        # Connect to the XMPP server and start processing XMPP stanzas.
-        if xmpp.connect((config['server'], config['port']), config['retry'], config['use_tls'], config['use_ssl']):
-            # If you do not have the dnspython library installed, you will need
-            # to manually specify the name of the server if it does not match
-            # the one in the JID. For example, to use Google Talk you would
-            # need to use:
-            #
-            # if xmpp.connect(('talk.google.com', 5222)):
-            #     ...
-            xmpp.process(block=True)
-            if os.path.isfile('/tmp/exit_nwws'):
-                os.remove('/tmp/exit_nwws')
-                sys.exit(1)
-        else:
-            print("Unable to connect.")
-            sys.exit(1)
+            print("INFO\t Connected to XMPP server, starting to process incoming products.")
+            xmpp.process()
 
-        print('Sleeping for 5 seconds..')
-        time.sleep(5) 
+        except ConnectionResetError:
+            print("ERROR\t Caught ConnectionResetError exception, restarting..")
+        except Exception as e:
+            print("ERROR\t Caught " + str(type(e)) + ' exception:')
+            print(e)
+            print("ERROR\t Restarting..")
 
+        print("INFO\t Sleeping for 5 seconds...")
+        time.sleep(5)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+slixmpp


### PR DESCRIPTION
These are the changes to convert the `nwws.py` script to use [Slixmpp](https://slixmpp.readthedocs.io/en/latest/) instead of [SleekXMPP](https://sleekxmpp.readthedocs.io/en/latest/).

The Dockerfile now uses the `python:3` image w/ associated `requirements.txt` file, instead of the `ubuntu:22.04` image for simplicity and speed.

The `docker-compose.yml` file has been renamed to `compose.yml` and the Docker Compose version has also been removed since it is now deprecated.

The changes have been tested locally and confirmed to be working.