### PR TITLE
Work with slixmpp-1.10

### DIFF
--- a/nwws.py
+++ b/nwws.py
@@ -9,6 +9,7 @@ import json
 import time
 import ssl
 import sys
+import asyncio
 import slixmpp
 from datetime import datetime, timezone
 from xml.dom import minidom
@@ -161,7 +162,7 @@ if __name__ == '__main__':
             xmpp.connect()
 
             print("INFO\t Connected to XMPP server, starting to process incoming products.")
-            xmpp.process()
+            asyncio.get_event_loop().run_forever()
 
         except ConnectionResetError:
             print("ERROR\t Caught ConnectionResetError exception, restarting..")


### PR DESCRIPTION
With slixmpp-1.10 (debian sid), I get this error:
```
ozymandias 38 # python nwws.py ./config.json 
Using slower stringprep, consider using cargo to build the faster version in rust.
INFO     Connecting to XMPP server..
INFO     Connected to XMPP server, starting to process incoming products.
ERROR    Caught <class 'AttributeError'> exception:
'MUCBot' object has no attribute 'process'
ERROR    Restarting..
```
These changes, based on https://slixmpp.readthedocs.io/en/latest/getting_started/muc.html, seem to make things work.

I _really_ don't know what I'm doing here...